### PR TITLE
prusa-connect-camera@.service

### DIFF
--- a/prusa-connect-camera@.service
+++ b/prusa-connect-camera@.service
@@ -6,6 +6,7 @@ After=network.target
 User=pi
 Group=pi
 EnvironmentFile=/home/pi/src/prusa-connect-camera-script/.%i
+ExecStartPre=/bin/sleep 30
 ExecStart=/home/pi/src/prusa-connect-camera-script/prusa-connect-camera.sh
 Restart=on-failure
 


### PR DESCRIPTION
Added an ExecStartPre with a 30 second sleep timer in order to solve an issue where the camera was not recognized on boot.