### PR TITLE
 Add a troubleshooting link to the Prusa status page, in case the service is down

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -14,6 +14,9 @@ Things to check if it does not work.
   then probably you have issues with permissions when running script
   for the second time (see below)
 
+- check that the [Prusa Connect `cameras` service](https://status.prusa3d.com/)
+  is running
+
 ## System file permissions
 
 Check files under `/dev/shm/camera*` and `/dev/video0`


### PR DESCRIPTION
First off, excellent script. Thank you for doing this!

I've successfully configured my Raspberry Pi Zero 2W with an Arducam module 3 using rpicam-apps-lite, and everything went well until I ran the script the first time - 503 error from Prusa. Turns out the service is down this weekend.

This change to the docs adds a link to the Prusa status page on the troubleshooting page.